### PR TITLE
Solving the error "Cannot resolve module 'child_process' and 'fs'"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,9 @@ if(minimize) {
 }
 
 module.exports = {
+  externals:[{
+    xmlhttprequest: '{XMLHttpRequest:XMLHttpRequest}'
+  }],
   entry: {
     javascript: './src/main.js'
   },


### PR DESCRIPTION
Got these errors **Cannot resolve module 'child_process'** and **Cannot resolve module 'fs'** when building the project (_XMLHttpRequest_). Node v10.4.1 and npm v6.4.1. 

Adding the code above to the webpack.config.js fixed the errors for me.

`
  externals:[{
    xmlhttprequest: '{XMLHttpRequest:XMLHttpRequest}'
  }],
`

By the way, thanks for sharing this awesome project! I will study it!